### PR TITLE
Minor optimization to line 196

### DIFF
--- a/moslime.py
+++ b/moslime.py
@@ -193,7 +193,7 @@ class NotificationHandler(btle.DefaultDelegate): #takes in tracker data, applies
                 ay = hexToFloat(data[28:30])
                 if self.ignorePackets == 0:
                     # Once a number of packets have been discarded, we calculate the offset needed to make SlimeVR happy
-                    self.offset = multiply(pw, -px, -py, -pz, 1, 0, 0, 0)
+                    self.offset = (pw, -px, -py, -pz)
                     self.ignorePackets += 1
                     self.lastCounter = int.from_bytes(data[1:8], "little")
                     return


### PR DESCRIPTION
A very small optimization to line 196. Multiplying a quaternion by 1, 0, 0, 0 returns the same quaternion. As such, the multiply function is not needed here and the values can be directly assigned into the variable.

This is a very minor efficiency gain since this line is only called once.